### PR TITLE
chore: trigger rebuild on GitHub to pull in theme changes

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -53,6 +53,9 @@ plugins:
   - jekyll-remote-theme
   - jekyll-include-cache
 
+# Still need to look into build and caching issues from Barry, using a constant in config for now so we know a build is triggered.
+build: 2
+
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list
 # to override the default setting.


### PR DESCRIPTION
We had issues during Barry and I haven't had a chance to look into a better way of doing this. Ideally a day will come when it's not necessary to update a theme much during a response.

Today, isn't that day.